### PR TITLE
[feat/sentry-only-at-prod]

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "deploy": "gh-pages -d build"
   },
   "devDependencies": {
-    "@redux-devtools/extension": "^3.3.0",
+    "@redux-devtools/extension": "^4.0.0",
     "@sentry/vite-plugin": "^5.1.1",
     "@vitejs/plugin-react": "^5.1.4",
     "eslint-plugin-react": "^7.34.0",

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -1,11 +1,12 @@
 import * as Sentry from "@sentry/react";
 
 const dsn = import.meta.env.VITE_SENTRY_DSN;
+const environment = import.meta.env.VITE_SENTRY_ENVIRONMENT || "production";
 
-if (dsn) {
+if (dsn && environment === "production") {
   Sentry.init({
     dsn,
-    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT || "production",
+    environment,
     release: import.meta.env.VITE_VERSION,
     integrations: [
       Sentry.browserTracingIntegration(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,7 +144,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.14.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.19.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.14.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.19.0", "@babel/runtime@^7.9.2":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
@@ -365,13 +365,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@redux-devtools/extension@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.3.0.tgz"
-  integrity sha512-X34S/rC8S/M1BIrkYD1mJ5f8vlH0BDqxXrs96cvxSBo4FhMdbhU+GUGsmNYov1xjSyLMHgo8NYrUG8bNX7525g==
-  dependencies:
-    "@babel/runtime" "^7.23.2"
-    immutable "^4.3.4"
+"@redux-devtools/extension@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@redux-devtools/extension/-/extension-4.0.0.tgz#bd03401ff0f033350b1f0bfa9b210029c5450627"
+  integrity sha512-pLIzgo5MvqdDLe5D1pzHLgmr8THra/DOyRf5MvOEPZnKKDn6RhFbNSS5oXZ3Cal0cpx08kx7sR6zD8QgoXEnZA==
 
 "@rolldown/pluginutils@1.0.0-rc.3":
   version "1.0.0-rc.3"
@@ -1550,11 +1547,6 @@ immutability-helper@^2.0.0:
   integrity sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==
   dependencies:
     invariant "^2.2.0"
-
-immutable@^4.3.4:
-  version "4.3.7"
-  resolved "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz"
-  integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
 
 internal-slot@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary
- Restrict Sentry initialization to production environment only, avoiding noise from dev.ameba.cat
- Update @redux-devtools/extension to v4 to fix immutable Prototype Pollution vulnerability (CVE-2026-29063)

## Changes
- sentry updated

## Files changed
- package.json — bump @redux-devtools/extension to ^4.0.0
- src/sentry.js — only initialize Sentry when environment is "production"
- yarn.lock — updated dependencies
