### PR TITLE
[fix/duplicated-items-in-cart]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ameba-site",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "private": true,
   "packageManager": "yarn@1.22.22",
   "homepage": "/",

--- a/src/components/navbar/Cart.jsx
+++ b/src/components/navbar/Cart.jsx
@@ -13,7 +13,8 @@ import useCartStore from "../../stores/useCartStore";
 import "./DropdownCart.css";
 
 function Cart() {
-  const { cart_data = {}, addToCart, substractToCart } = useCartStore();
+  const { cart_data = {}, addToCart, substractToCart, cartBusy } =
+    useCartStore();
   const { isLoggedIn } = useAuthStore();
   const setGuestUser = useProfileStore((state) => state.setGuestUser);
   const setLoggedUser = useProfileStore((state) => state.setLoggedUser);
@@ -88,14 +89,14 @@ function Cart() {
                         <div className="rowCartProduct">
                           <div className="colCartProduct1">
                             <div
-                              className="addCart"
-                              onClick={() => addItem(el.id)}
+                              className={`addCart${cartBusy ? " disabled" : ""}`}
+                              onClick={() => !cartBusy && addItem(el.id)}
                             >
                               <Icon icon="plus" />
                             </div>
                             <div
-                              className="subsCart"
-                              onClick={() => substractItem(el.id)}
+                              className={`subsCart${cartBusy ? " disabled" : ""}`}
+                              onClick={() => !cartBusy && substractItem(el.id)}
                             >
                               <Icon icon="minus" />
                             </div>

--- a/src/components/navbar/DropdownCart.css
+++ b/src/components/navbar/DropdownCart.css
@@ -148,6 +148,13 @@
     }
 }
 
+.addCart.disabled,
+.subsCart.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 .buttonCheckoutCart {
     background-color: #1d1d1b;
     font-size: 20px;

--- a/src/components/navbar/DropdownCartMobile.jsx
+++ b/src/components/navbar/DropdownCartMobile.jsx
@@ -15,7 +15,7 @@ import Icon from "../ui/Icon";
 import useMediaQuery from "../../hooks/use-media-query";
 
 export default function DropdownCartMobile(props) {
-  const { addToCart, substractToCart } = useCartStore();
+  const { addToCart, substractToCart, cartBusy } = useCartStore();
   const { setCartMenuOpen = {} } = props;
   const { item_variants = [], total = 0 } = props.cartData;
   const { isLoggedIn } = useAuthStore();
@@ -112,12 +112,15 @@ export default function DropdownCartMobile(props) {
                     </div>
                   </div>
                   <div className="colCartProduct2_mobile">
-                    <div className="addCart" onClick={() => addItem(el.id)}>
+                    <div
+                      className={`addCart${cartBusy ? " disabled" : ""}`}
+                      onClick={() => !cartBusy && addItem(el.id)}
+                    >
                       <Icon icon="plus" />
                     </div>
                     <div
-                      className="subsCart"
-                      onClick={() => substractItem(el.id)}
+                      className={`subsCart${cartBusy ? " disabled" : ""}`}
+                      onClick={() => !cartBusy && substractItem(el.id)}
                     >
                       <Icon icon="minus" />
                     </div>

--- a/src/stores/useCartStore.js
+++ b/src/stores/useCartStore.js
@@ -2,17 +2,21 @@ import { create } from "zustand";
 import CartService from "../store/services/cart.services";
 import notificationToast from "../utils/utils";
 
-const useCartStore = create((set) => ({
+const useCartStore = create((set, get) => ({
   cart_data: {},
   checkout: {},
   stripe: false,
+  cartBusy: false,
 
   addToCart: (id) => {
+    if (get().cartBusy) return Promise.resolve();
+    set({ cartBusy: true });
     return CartService.addInCart(id).then(
       (response) => {
-        set({ cart_data: response });
+        set({ cart_data: response, cartBusy: false });
       },
       (error) => {
+        set({ cartBusy: false });
         const message = error.response?.data?.detail;
         notificationToast(message, "error");
         return Promise.reject();
@@ -21,11 +25,14 @@ const useCartStore = create((set) => ({
   },
 
   substractToCart: (id) => {
+    if (get().cartBusy) return Promise.resolve();
+    set({ cartBusy: true });
     return CartService.removeItemCart(id).then(
       (response) => {
-        set({ cart_data: response });
+        set({ cart_data: response, cartBusy: false });
       },
       (error) => {
+        set({ cartBusy: false });
         const message = error.response?.data?.detail;
         notificationToast(message, "error");
         return Promise.reject();

--- a/src/utils/utils.jsx
+++ b/src/utils/utils.jsx
@@ -71,9 +71,7 @@ export function isMemberCheckout(input) {
 }
 
 export function mergeCartIds(arr1, arr2) {
-  if (arr1.length < 1 || arr2.length < 1) return arr1.length ? arr1 : arr2;
-  if (arr1.sort().join(",") === arr2.sort().join(",")) return arr1;
-  else return arr1.concat(arr2);
+  return [...new Set([...arr1, ...arr2])];
 }
 
 // Funcion que calcula cuantas celdas vacias hay en ultima fila y permite alinear el ultimo elemento


### PR DESCRIPTION
[fix/duplicated-items-in-cart]

## Summary
- Fix cart merge logic that caused duplicate items when combining local and remote carts on login
- Add race condition protection: lock cart operations to prevent double-click duplicates
- Disable +/- cart buttons visually while a cart operation is in progress

## Changes
- Version 3.4.4
- Fix `mergeCartIds` to deduplicate using `Set` instead of blind `concat`
- Add `cartBusy` locking state in `useCartStore` for `addToCart` / `substractToCart`
- Disable +/- buttons in `Cart` and `DropdownCartMobile` while cart is busy
- Add `.disabled` CSS styles for cart action buttons

## Files changed
- package.json
- src/utils/utils.jsx
- src/stores/useCartStore.js
- src/components/navbar/Cart.jsx
- src/components/navbar/DropdownCartMobile.jsx
- src/components/navbar/DropdownCart.css