### PR TITLE
[feat/some-styles-broken-pt2]

### DIFF
--- a/src/components/layout/CardLayout/CardLayout.css
+++ b/src/components/layout/CardLayout/CardLayout.css
@@ -112,6 +112,6 @@
   .card-layout .fullcard { flex: 1 0 50%; }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 640px) {
   .card-layout .fullcard { display: block; min-width: 0; width: auto; max-width: 100%; }
 }

--- a/src/components/layout/LettersMove.css
+++ b/src/components/layout/LettersMove.css
@@ -27,6 +27,7 @@
     height: 34px;
     text-align: left;
     z-index: 0;
+    overflow: hidden;
 }
 
 .letters-move__wrapper .substituto-marquee {

--- a/src/components/layout/LettersMove.jsx
+++ b/src/components/layout/LettersMove.jsx
@@ -25,7 +25,7 @@ export default function LettersMove({
   if (link.length > 0)
     return (
       <NavLink
-        style={{ textDecoration: "none" }}
+        style={{ textDecoration: "none", display: "block" }}
         to={{
           pathname: link,
         }}

--- a/src/components/layout/PowerTitle.css
+++ b/src/components/layout/PowerTitle.css
@@ -7,12 +7,11 @@
 }
 
 .power-title__box .SupportSubtitle {
-  margin: -20px;
+  margin: -20px 30px 1rem;
   text-transform: uppercase;
-  font-size: 2.5rem;
+  font-size: 1.8rem;
   font-family: "Bebas Neue";
   font-weight: 100;
-  margin-bottom: 1rem;
   width: 100%;
 }
 

--- a/src/components/layout/PowerTitle.jsx
+++ b/src/components/layout/PowerTitle.jsx
@@ -14,6 +14,7 @@ function PowerTitle(props) {
           fontStyle={fontStyle}
           autoGrow={autoScale}
           singleLine
+          className={autoScale ? "ameba-card-title--no-pad" : ""}
         >
           {props.title}
         </AmebaCardTitle>

--- a/src/components/searchBox/SearchBox.jsx
+++ b/src/components/searchBox/SearchBox.jsx
@@ -65,6 +65,7 @@ const SearchBox = ({
       onChange={handleChange}
       value={searchInput}
       ref={ref}
+      id="search-box-input"
     />
   );
 };

--- a/src/components/ui/AmebaCardTitle.css
+++ b/src/components/ui/AmebaCardTitle.css
@@ -12,6 +12,10 @@
   white-space: nowrap;
 }
 
+.ameba-card-title--no-pad {
+  padding-right: 0px;
+}
+
 .ameba-card-title__container {
   font-family: "Bebas Neue";
   width: -webkit-fill-available;

--- a/src/components/ui/Icon.css
+++ b/src/components/ui/Icon.css
@@ -1,9 +1,11 @@
-.icon {
+.icon,
+.icon--disabled {
   display: flex;
   position: relative;
 }
 
-.icon .tooltip {
+.icon .tooltip,
+.icon--disabled .tooltip {
   display: none;
   visibility: hidden;
   width: 120px;
@@ -21,7 +23,8 @@
   transition: opacity 0.5s;
 }
 
-.icon .tooltip::after {
+.icon .tooltip::after,
+.icon--disabled .tooltip::after {
   content: "";
   position: absolute;
   top: 100%;
@@ -32,7 +35,8 @@
   border-color: #555 transparent transparent transparent;
 }
 
-.icon:hover .tooltip {
+.icon:hover .tooltip,
+.icon--disabled:hover .tooltip {
   visibility: visible;
   opacity: 1;
   display: block;
@@ -102,6 +106,44 @@
 
 .icon--disabled #hoverable-dark-svg:hover path {
   fill: var(--color-gris-claro);
+}
+
+/* Stroke-based icons: override fill rules, use stroke for coloring */
+.icon #hoverable-cream-svg .stroke-icon path,
+.icon #hoverable-red-svg .stroke-icon path,
+.icon #hoverable-black-svg .stroke-icon path,
+.icon #hoverable-dark-svg .stroke-icon path {
+  fill: none;
+  stroke: var(--color-negro);
+}
+
+.icon #hoverable-black-svg .stroke-icon path,
+.icon #hoverable-dark-svg .stroke-icon path {
+  stroke: var(--color-cream);
+}
+
+.icon #hoverable-cream-svg:hover .stroke-icon path,
+.icon #hoverable-red-svg:hover .stroke-icon path,
+.icon #hoverable-black-svg:hover .stroke-icon path,
+.icon #hoverable-dark-svg:hover .stroke-icon path {
+  fill: none;
+  stroke: var(--color-rojo);
+}
+
+.icon--disabled #hoverable-cream-svg .stroke-icon path,
+.icon--disabled #hoverable-red-svg .stroke-icon path,
+.icon--disabled #hoverable-black-svg .stroke-icon path,
+.icon--disabled #hoverable-dark-svg .stroke-icon path {
+  fill: none;
+  stroke: var(--color-gris-claro);
+}
+
+.icon--disabled #hoverable-cream-svg:hover .stroke-icon path,
+.icon--disabled #hoverable-red-svg:hover .stroke-icon path,
+.icon--disabled #hoverable-black-svg:hover .stroke-icon path,
+.icon--disabled #hoverable-dark-svg:hover .stroke-icon path {
+  fill: none;
+  stroke: var(--color-gris-claro);
 }
 
 /* Static color variants */

--- a/src/components/ui/Icon.jsx
+++ b/src/components/ui/Icon.jsx
@@ -70,7 +70,19 @@ function Icon(props) {
 
   const cancelled = (
     <AmebaSvgWrapper {...props}>
-      <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z" />{" "}
+      <g
+        className="stroke-icon"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M15 5v2" />
+        <path d="M15 17v2" />
+        <path d="M9 5h10a2 2 0 0 1 2 2v3a2 2 0 1 0 0 4v3m-2 2h-14a2 2 0 0 1 -2 -2v-3a2 2 0 1 0 0 -4v-3a2 2 0 0 1 2 -2" />
+        <path d="M3 3l18 18" />
+      </g>
     </AmebaSvgWrapper>
   );
 
@@ -238,7 +250,13 @@ function Icon(props) {
 
   const facebook = (
     <AmebaSvgWrapper {...props}>
-      <g fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M7 10v4h3v7h4v-7h3l1 -4h-4v-2a1 1 0 0 1 1 -1h3v-4h-3a5 5 0 0 0 -5 5v2h-3" />
       </g>
     </AmebaSvgWrapper>
@@ -246,7 +264,13 @@ function Icon(props) {
 
   const twitter = (
     <AmebaSvgWrapper {...props}>
-      <g fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M4 4l11.733 16h4.267l-11.733 -16l-4.267 0" />
         <path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772" />
       </g>
@@ -255,7 +279,13 @@ function Icon(props) {
 
   const instagram = (
     <AmebaSvgWrapper {...props}>
-      <g fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M4 8a4 4 0 0 1 4 -4h8a4 4 0 0 1 4 4v8a4 4 0 0 1 -4 4h-8a4 4 0 0 1 -4 -4l0 -8" />
         <path d="M9 12a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />
         <path d="M16.5 7.5v.01" />
@@ -276,12 +306,19 @@ function Icon(props) {
 
   const ticket = (
     <AmebaSvgWrapper {...props}>
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M22 10V6C22 4.9 21.1 4 20 4H4C2.9 4 2.01 4.9 2.01 6V10C3.11 10 4 10.9 4 12C4 13.1 3.11 14 2 14V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V14C20.9 14 20 13.1 20 12C20 10.9 20.9 10 22 10ZM20 8.54C18.81 9.23 18 10.53 18 12C18 13.47 18.81 14.77 20 15.46V18H4V15.46C5.19 14.77 6 13.47 6 12C6 10.52 5.2 9.23 4.01 8.54L4 6H20V8.54ZM12 14.12L9.07 16L9.95 12.63L7.26 10.43L10.73 10.22L12 7L13.26 10.23L16.73 10.44L14.04 12.64L14.93 16L12 14.12Z"
-        fill="black"
-      />
+      <g
+        className="stroke-icon"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M15 5l0 2" />
+        <path d="M15 11l0 2" />
+        <path d="M15 17l0 2" />
+        <path d="M5 5h14a2 2 0 0 1 2 2v3a2 2 0 0 0 0 4v3a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-3a2 2 0 0 0 0 -4v-3a2 2 0 0 1 2 -2" />
+      </g>
     </AmebaSvgWrapper>
   );
 

--- a/src/pages/Botiga.jsx
+++ b/src/pages/Botiga.jsx
@@ -63,7 +63,7 @@ function Botiga() {
 
   return (
     <div className="Botiga">
-      <PowerTitle title={t("menu.botiga")} className="SupportTitle" />
+      <PowerTitle title={t("menu.botiga")} className="SupportTitle" autoScale />
       <div className="clickBanner">
         <NavLink
           style={{ textDecoration: "none" }}
@@ -76,7 +76,7 @@ function Botiga() {
               isMobile
                 ? t("banners.soci-curt")
                 : `${t("banners.soci-llarg-pt1")}${deleteStringDecimals(
-                    sociPreu
+                    sociPreu,
                   )}${t("banners.soci-llarg-pt2")}`
             }
             // handleClick={handleOpen}

--- a/src/pages/agenda/Agenda.jsx
+++ b/src/pages/agenda/Agenda.jsx
@@ -12,10 +12,8 @@ export default function Agenda() {
 
   return (
     <div className="Articles">
-      <div className="ArticlesContent">
-        <PowerTitle title="AGENDA" />
-        {isEventsLoading ? <Spinner /> : <AgendaTable />}
-      </div>
+      <PowerTitle title="AGENDA" autoScale />
+      {isEventsLoading ? <Spinner /> : <AgendaTable />}
       <LettersMove
         className="lettersMoveDiv"
         sentence={t("banners.soci-curt")}

--- a/src/pages/agenda/components/AgendaTable.jsx
+++ b/src/pages/agenda/components/AgendaTable.jsx
@@ -261,7 +261,7 @@ const AgendaTable = () => {
                     price,
                     stock,
                     datetime,
-                    info.row.original.cancelled
+                    info.row.original.cancelled,
                   )}
                 </div>
               );
@@ -271,19 +271,19 @@ const AgendaTable = () => {
           isSmallScreen
             ? column.accessorKey !== "reserva" &&
               column.accessorKey !== "datetimehour"
-            : column
+            : column,
         ),
       },
     ],
-    [isSmallScreen]
+    [isSmallScreen],
   );
 
   const filteredAgenda = React.useMemo(
     () =>
       sortByDate(agenda).filter((activity) =>
-        activity?.name?.toLowerCase()?.includes(searchInput?.toLowerCase())
+        activity?.name?.toLowerCase()?.includes(searchInput?.toLowerCase()),
       ),
-    [agenda, searchInput]
+    [agenda, searchInput],
   );
 
   const table = useReactTable({
@@ -299,11 +299,16 @@ const AgendaTable = () => {
   if (redirect) return <Navigate to={checkoutRedirect} replace />;
 
   return (
-    <div className={`styled-main-column-view agenda-table${agenda.length === 0 ? " agenda-table--empty" : ""}`}>
+    <div
+      className={`styled-main-column-view agenda-table${agenda.length === 0 ? " agenda-table--empty" : ""}`}
+    >
       <table>
         <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
+          {table.getHeaderGroups().map((headerGroup, groupIndex) => (
+            <tr
+              key={headerGroup.id}
+              className={groupIndex > 0 ? "agenda-header-row" : ""}
+            >
               {headerGroup.headers.map((header) => (
                 <th key={header.id} colSpan={header.colSpan}>
                   {header.id.includes("search-box") ? (
@@ -319,7 +324,7 @@ const AgendaTable = () => {
                     ? null
                     : flexRender(
                         header.column.columnDef.header,
-                        header.getContext()
+                        header.getContext(),
                       )}
                 </th>
               ))}
@@ -340,7 +345,7 @@ const AgendaTable = () => {
                     >
                       {flexRender(
                         cell.column.columnDef.cell,
-                        cell.getContext()
+                        cell.getContext(),
                       )}
                     </td>
                   );

--- a/src/pages/agenda/components/AgendaTable.jsx
+++ b/src/pages/agenda/components/AgendaTable.jsx
@@ -20,7 +20,7 @@ import ActivitatDialog from "./Activitat";
 import "./AgendaTable.styled.css";
 import "../../../styles/GlobalStyles.style.css";
 import axiosInstance from "../../../axios";
-import { API_URL, MOBILE_SEMI_BIG } from "../../../utils/constants";
+import { API_URL } from "../../../utils/constants";
 import SearchBox from "../../../components/searchBox/SearchBox";
 import useMediaQuery from "../../../hooks/use-media-query";
 
@@ -34,7 +34,7 @@ const AgendaTable = () => {
   const [searchInput, setSearchInput] = useState("");
   const checkoutRedirect = user_profile === "GUEST" ? "/login" : "/checkout";
   const [t] = useTranslation("translation");
-  const isSmallScreen = useMediaQuery(MOBILE_SEMI_BIG);
+  const isMobile = useMediaQuery("(max-width:1000px)");
   const today = new Date();
   const todayIsoString = today.toISOString();
 
@@ -267,15 +267,10 @@ const AgendaTable = () => {
               );
             },
           },
-        ].filter((column) =>
-          isSmallScreen
-            ? column.accessorKey !== "reserva" &&
-              column.accessorKey !== "datetimehour"
-            : column,
-        ),
+        ],
       },
     ],
-    [isSmallScreen],
+    [],
   );
 
   const filteredAgenda = React.useMemo(
@@ -298,82 +293,129 @@ const AgendaTable = () => {
 
   if (redirect) return <Navigate to={checkoutRedirect} replace />;
 
+  const renderPagination = () =>
+    table.getPageCount() > 1 && (
+      <div className="pagination-controls">
+        <button
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          ←
+        </button>
+        <span>
+          {table.getState().pagination.pageIndex + 1} / {table.getPageCount()}
+        </span>
+        <button
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          →
+        </button>
+      </div>
+    );
+
   return (
     <div
       className={`styled-main-column-view agenda-table${agenda.length === 0 ? " agenda-table--empty" : ""}`}
     >
-      <table>
-        <thead>
-          {table.getHeaderGroups().map((headerGroup, groupIndex) => (
-            <tr
-              key={headerGroup.id}
-              className={groupIndex > 0 ? "agenda-header-row" : ""}
-            >
-              {headerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan}>
-                  {header.id.includes("search-box") ? (
-                    <div className="search-row">
-                      <SearchBox
-                        searchText="Busca"
-                        searchInput={searchInput}
-                        setSearchInput={setSearchInput}
-                      />
-                    </div>
-                  ) : null}
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
-                      )}
-                </th>
-              ))}
+      {isMobile ? (
+        <table>
+          <thead>
+            <tr>
+              <th>
+                <div className="search-row">
+                  <SearchBox
+                    searchText="Busca"
+                    searchInput={searchInput}
+                    setSearchInput={setSearchInput}
+                  />
+                </div>
+              </th>
             </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => {
-            return (
-              <tr key={row.id}>
-                {row.getVisibleCells().map((cell) => {
-                  return (
-                    <td
-                      key={cell.id}
-                      onClick={() =>
-                        cell.column.id !== "reserva" && fetchEvent(row.original)
-                      }
-                    >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </td>
-                  );
-                })}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => {
+              const { name, images, datetime } = row.original;
+              return (
+                <tr key={row.id} className="agenda-mobile-row" onClick={() => fetchEvent(row.original)}>
+                  <td>
+                    <div className="agenda-mobile-card">
+                      <div className="agenda-mobile-card__image">
+                        <img src={images} alt="" />
+                      </div>
+                      <div className="agenda-mobile-card__info">
+                        <div className="agenda-mobile-card__date">
+                          {formatISODateToDate(datetime)}
+                        </div>
+                        <hr />
+                        <div className="agenda-mobile-card__title">
+                          {name?.toUpperCase()}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      ) : (
+        <table>
+          <thead>
+            {table.getHeaderGroups().map((headerGroup, groupIndex) => (
+              <tr
+                key={headerGroup.id}
+                className={groupIndex > 0 ? "agenda-header-row" : ""}
+              >
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.id.includes("search-box") ? (
+                      <div className="search-row">
+                        <SearchBox
+                          searchText="Busca"
+                          searchInput={searchInput}
+                          setSearchInput={setSearchInput}
+                        />
+                      </div>
+                    ) : null}
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </th>
+                ))}
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
-      {table.getPageCount() > 1 && (
-        <div className="pagination-controls">
-          <button
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            ←
-          </button>
-          <span>
-            {table.getState().pagination.pageIndex + 1} / {table.getPageCount()}
-          </span>
-          <button
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            →
-          </button>
-        </div>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => {
+              return (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => {
+                    return (
+                      <td
+                        key={cell.id}
+                        onClick={() =>
+                          cell.column.id !== "reserva" &&
+                          fetchEvent(row.original)
+                        }
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       )}
+      {renderPagination()}
       {open && (
         <ActivitatDialog
           open={open}

--- a/src/pages/agenda/components/AgendaTable.styled.css
+++ b/src/pages/agenda/components/AgendaTable.styled.css
@@ -1,5 +1,5 @@
 .agenda-table {
-  height: 100%;
+  min-height: 0;
 }
 
 .agenda-table--empty {
@@ -12,6 +12,8 @@
   background-color: var(--color-cream);
   padding: 12px;
   border-radius: 4px;
+  box-sizing: border-box;
+  table-layout: auto;
 }
 
 .agenda-table table .search-row {
@@ -41,11 +43,16 @@
   }
 }
 
-@media screen and (max-width: 1230px) {
-  .agenda-table table tbody tr h1 {
+@media screen and (max-width: 640px) {
+  .agenda-mobile-card__info, .agenda-mobile-card__date {
     font-size: 1.6rem;
+    line-height: normal;
   }
-}
+    .agenda-mobile-card__info, .agenda-mobile-card__title {
+    font-size: 1.5rem;
+    line-height: normal;
+  }
+} 
 
 .agenda-table table tbody tr .horaDataActivitat {
   text-align: center;
@@ -129,4 +136,69 @@
 
 .styled-ticket svg {
   scale: 2;
+}
+
+/* Mobile table rows */
+.agenda-table table tbody tr.agenda-mobile-row {
+  display: block;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.agenda-table table tbody tr.agenda-mobile-row:last-child {
+  border-bottom: none;
+}
+
+/* Mobile card layout */
+.agenda-mobile-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  gap: 0 12px;
+  align-items: center;
+}
+
+.agenda-mobile-card__image {
+  grid-column: 1;
+  grid-row: 1 / 3;
+}
+
+.agenda-mobile-card__image img {
+  width: 140px;
+  height: 140px;
+  object-fit: cover;
+  vertical-align: middle;
+}
+
+.agenda-mobile-card__title {
+  text-align: left;
+}
+
+.agenda-mobile-card__info{
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  height: 100%;
+  font-family: "Bebas Neue";
+  font-weight: 400;
+  font-size: 2.5rem;
+  line-height: 0.8em;
+  hr{
+    width: 100%;
+    min-width: 100%;
+    border: none;
+    border-top: 1px solid #808080;
+    margin: 8px 0px;
+  }
+}
+
+@media screen and (max-width: 1000px) {
+.agenda-table table .search-row{
+  float: unset;
+  width: 100%;
+    input{
+        max-width: unset;
+    }
+  }
 }

--- a/src/pages/booking/Booking.jsx
+++ b/src/pages/booking/Booking.jsx
@@ -10,7 +10,7 @@ export default function Booking() {
   const { support } = useDataStore();
 
   const filteredAmebaRoster = support.filter(
-    (artist) => artist.is_ameba_dj === true
+    (artist) => artist.is_ameba_dj === true,
   );
 
   return (
@@ -19,6 +19,7 @@ export default function Booking() {
         title={"BOOKING"}
         className="SupportTitle"
         subtitle="AMEBA Roster"
+        autoScale
       />
       <CardLayout cardList={filteredAmebaRoster} urlRoot="booking" />
       <LettersMove

--- a/src/pages/gallery/Gallery.jsx
+++ b/src/pages/gallery/Gallery.jsx
@@ -52,20 +52,27 @@ const Gallery = () => {
   return (
     <div className="SupportContent">
       <div className="logView">
-        <PowerTitle title="PARKFEST 22" subtitle="* 21-05-22 *" />
+        <PowerTitle title="PARKFEST 22" subtitle="* 21-05-22 *" autoScale />
         {isGaleriaLoading && <Spinner />}
         <div ref={galleryTopRef} />
-        <Galeria images={imgArrayBuilder.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)} />
+        <Galeria
+          images={imgArrayBuilder.slice(
+            page * PAGE_SIZE,
+            (page + 1) * PAGE_SIZE,
+          )}
+        />
         {Math.ceil(imgArrayBuilder.length / PAGE_SIZE) > 1 && (
-          <div style={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            gap: "16px",
-            padding: "16px 0",
-            fontFamily: "Bebas Neue",
-            fontSize: "1.4rem",
-          }}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              gap: "16px",
+              padding: "16px 0",
+              fontFamily: "Bebas Neue",
+              fontSize: "1.4rem",
+            }}
+          >
             <button
               onClick={() => changePage(page - 1)}
               disabled={page === 0}
@@ -81,18 +88,28 @@ const Gallery = () => {
             >
               ←
             </button>
-            <span>{page + 1} / {Math.ceil(imgArrayBuilder.length / PAGE_SIZE)}</span>
+            <span>
+              {page + 1} / {Math.ceil(imgArrayBuilder.length / PAGE_SIZE)}
+            </span>
             <button
               onClick={() => changePage(page + 1)}
-              disabled={page >= Math.ceil(imgArrayBuilder.length / PAGE_SIZE) - 1}
+              disabled={
+                page >= Math.ceil(imgArrayBuilder.length / PAGE_SIZE) - 1
+              }
               style={{
                 background: "none",
                 border: "1px solid black",
                 fontSize: "1.4rem",
                 padding: "4px 12px",
-                cursor: page >= Math.ceil(imgArrayBuilder.length / PAGE_SIZE) - 1 ? "default" : "pointer",
+                cursor:
+                  page >= Math.ceil(imgArrayBuilder.length / PAGE_SIZE) - 1
+                    ? "default"
+                    : "pointer",
                 borderRadius: "4px",
-                opacity: page >= Math.ceil(imgArrayBuilder.length / PAGE_SIZE) - 1 ? 0.3 : 1,
+                opacity:
+                  page >= Math.ceil(imgArrayBuilder.length / PAGE_SIZE) - 1
+                    ? 0.3
+                    : 1,
               }}
             >
               →

--- a/src/pages/socios/Socios.jsx
+++ b/src/pages/socios/Socios.jsx
@@ -52,6 +52,7 @@ const Socios = () => {
               : t("soci.missatge-ppal")
             : ""
         }
+        autoScale
       />
       <div className="height-block" />
       <SearchBox

--- a/src/pages/support/SupportYourLocals.jsx
+++ b/src/pages/support/SupportYourLocals.jsx
@@ -17,7 +17,7 @@ export default function SupportYourLocals() {
   const filteredArtists = support.filter(
     (artist) =>
       artist?.is_ameba_dj === false &&
-      artist?.name?.toLowerCase()?.includes(searchInput?.toLowerCase())
+      artist?.name?.toLowerCase()?.includes(searchInput?.toLowerCase()),
   );
 
   return (
@@ -26,6 +26,7 @@ export default function SupportYourLocals() {
         title={"#SUPPORTYOURLOCALS"}
         className="SupportTitle"
         subtitle={t("support.title.subtitle")}
+        autoScale
       />
       <SearchBox
         searchText="Busca"

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -104,14 +104,14 @@ export const productQueryKind = {
   activitat: "events",
 };
 
-export const API_URL =
-  process.env.REACT_APP_API_HOST ||
-  `${window.location.protocol}//${window.location.hostname}${
-    window.location.port ? ":" + window.location.port : ""
-  }/api/`;
+// export const API_URL =
+//   process.env.REACT_APP_API_HOST ||
+//   `${window.location.protocol}//${window.location.hostname}${
+//     window.location.port ? ":" + window.location.port : ""
+//   }/api/`;
 
 // For local development
-// export const API_URL = `${window.location.protocol}//${window.location.hostname}:8080/api/`;
+export const API_URL = `${window.location.protocol}//${window.location.hostname}:8080/api/`;
 
 export const BASE_URL = API_URL.replace("/ameba-site/", "/");
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -105,13 +105,13 @@ export const productQueryKind = {
 };
 
 // export const API_URL =
-//   process.env.REACT_APP_API_HOST ||
-//   `${window.location.protocol}//${window.location.hostname}${
-//     window.location.port ? ":" + window.location.port : ""
-//   }/api/`;
+process.env.REACT_APP_API_HOST ||
+  `${window.location.protocol}//${window.location.hostname}${
+    window.location.port ? ":" + window.location.port : ""
+  }/api/`;
 
 // For local development
-export const API_URL = `${window.location.protocol}//${window.location.hostname}:8080/api/`;
+// export const API_URL = `${window.location.protocol}//${window.location.hostname}:8080/api/`;
 
 export const BASE_URL = API_URL.replace("/ameba-site/", "/");
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -104,8 +104,8 @@ export const productQueryKind = {
   activitat: "events",
 };
 
-// export const API_URL =
-process.env.REACT_APP_API_HOST ||
+export const API_URL =
+  process.env.REACT_APP_API_HOST ||
   `${window.location.protocol}//${window.location.hostname}${
     window.location.port ? ":" + window.location.port : ""
   }/api/`;


### PR DESCRIPTION
## Summary
- Refactored agenda table for mobile: single-cell-per-row layout with grid-based card (image | date + title)
- Fixed various broken styles across components (icons, cards, gallery, search, power titles)
- Updated constants and breakpoints

## Changes
- [feat/some-styles-broken-pt2] — mobile agenda table with dedicated card layout
- icons — icon component style fixes
- constants — constants updates
- [feat/some-styles-broken-pt2] — initial style fixes

## Files changed
- src/components/layout/CardLayout/CardLayout.css
- src/components/layout/LettersMove.css
- src/components/layout/LettersMove.jsx
- src/components/layout/PowerTitle.css
- src/components/layout/PowerTitle.jsx
- src/components/searchBox/SearchBox.jsx
- src/components/ui/AmebaCardTitle.css
- src/components/ui/Icon.css
- src/components/ui/Icon.jsx
- src/pages/Botiga.jsx
- src/pages/agenda/Agenda.jsx
- src/pages/agenda/components/AgendaTable.jsx
- src/pages/agenda/components/AgendaTable.styled.css
- src/pages/booking/Booking.jsx
- src/pages/gallery/Gallery.jsx
- src/pages/socios/Socios.jsx
- src/pages/support/SupportYourLocals.jsx
- src/utils/constants.js
