### PR TITLE
[fix/img-broken]

### DIFF
--- a/src/components/layout/CardLayout/CardLayout.css
+++ b/src/components/layout/CardLayout/CardLayout.css
@@ -45,11 +45,16 @@
   container-type: inline-size;
 }
 
+.card-layout .cardSupport > .ameba-card-title__container {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
 .card-layout .cardSupportImgTop {
   display: block;
   width: 100%;
-  height: 500px;
-  max-height: 500px;
+  height: 100%;
   object-fit: cover;
   z-index: 0;
   transition: all 0.4s ease;


### PR DESCRIPTION
## Summary
- Fix cardSupport image not rendering because AmebaCardTitle was pushing it out of the overflow-hidden container
- Position the title absolutely over the image and make the image fill the card height

## Changes
- [fix/img-broken] Position `.ameba-card-title__container` absolutely within `.cardSupport` so the title overlays the image instead of displacing it. Changed image height from fixed 500px to 100% to properly fill the card.

## Files changed
- src/components/layout/CardLayout/CardLayout.css

