### PR TITLE
[fix/sentry-crash-recovery-email]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ameba-site",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "private": true,
   "packageManager": "yarn@1.22.22",
   "homepage": "/",

--- a/src/components/externalEvents/ExternalEvent.jsx
+++ b/src/components/externalEvents/ExternalEvent.jsx
@@ -162,7 +162,7 @@ const ExternalEvent = ({ productData = {}, kind = "", handleAddClick }) => {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {maps_url?.includes("dice") ? maps_url : address}
+                  {maps_url?.includes("dice") ? t("events.button.pago-externo") : address}
                 </a>
               </div>
             </div>

--- a/src/modals/InteractiveModalBox.jsx
+++ b/src/modals/InteractiveModalBox.jsx
@@ -118,7 +118,7 @@ const InteractiveModalBox = (props) => {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {maps_url?.includes("dice") ? maps_url : address}
+                  {maps_url?.includes("dice") ? t("events.button.pago-externo") : address}
                 </a>
               </div>
             </div>

--- a/src/modals/ModalCard.jsx
+++ b/src/modals/ModalCard.jsx
@@ -545,7 +545,7 @@ export default function ModalCard(props) {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    {maps_url?.includes("dice") ? maps_url : address}
+                    {maps_url?.includes("dice") ? t("events.button.pago-externo") : address}
                   </a>
                 </div>
               </div>
@@ -579,9 +579,11 @@ export default function ModalCard(props) {
               />
               {buttonMapper(type)}
             </div>
-            <hr
-              className={`modal-card__hr_dashed modal-card__hr_dashed-${colorMode}`}
-            />
+            {!(maps_url?.includes("dice")) && (
+              <hr
+                className={`modal-card__hr_dashed modal-card__hr_dashed-${colorMode}`}
+              />
+            )}
             <div className="modal-card__description-title">{box1Title}</div>
             <div className="modal-card__description-content">
               {urlify(box1Text)}

--- a/src/modals/ModalCardStyled.css
+++ b/src/modals/ModalCardStyled.css
@@ -4,6 +4,11 @@
   width: 100%;
 }
 
+.modal-row a {
+  text-decoration: none;
+  width: 100%;
+}
+
 .modal-row button {
   width: 100%;
   margin: 0 auto;

--- a/src/modals/Modals.css
+++ b/src/modals/Modals.css
@@ -291,6 +291,10 @@ hr>.modal-card__hr_dashed {
     margin: 10px 0px 20px 0px;
 }
 
+.modal-card-mobile__button-wrapper a {
+    text-decoration: none;
+    width: 100%;
+}
 
 /* InteractiveDataBox */
 

--- a/src/pages/PasswordRecovery.jsx
+++ b/src/pages/PasswordRecovery.jsx
@@ -1,19 +1,20 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 import PageLayout from "../components/layout/PageLayout/PageLayout";
 import PasswordRecoveryForm from "./../components/forms/PasswordRecoveryForm/PasswordRecoveryForm";
 import "../styles/GlobalStyles.css";
 
-export default function PasswordRecovery(props) {
+export default function PasswordRecovery() {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [strToken, setStrToken] = useState("");
-  const parsed = Object.fromEntries(new URLSearchParams(props.location.search));
+  const location = useLocation();
   const [t] = useTranslation("translation");
 
   useEffect(() => {
+    const parsed = Object.fromEntries(new URLSearchParams(location.search));
     setStrToken(parsed["token"] || parsed["?token"]);
-  }, [parsed, strToken, setStrToken]);
+  }, [location.search]);
 
   return (
     <PageLayout

--- a/src/pages/QrClient.jsx
+++ b/src/pages/QrClient.jsx
@@ -1,22 +1,23 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 import stateService from "./../store/services/profile.services";
 import PageLayout from "../components/layout/PageLayout/PageLayout";
 
-export default function QrClient(props) {
+export default function QrClient() {
   const [data, setData] = useState({});
-  const parsed = Object.fromEntries(new URLSearchParams(props.location.search));
+  const location = useLocation();
   const [t] = useTranslation("translation");
 
   useEffect(() => {
-    if (parsed["token"].length > 0) {
-      stateService
-        .getCarnet(parsed["token"] || parsed["?token"])
-        ?.then((data) => {
-          setData(data);
-        });
+    const parsed = Object.fromEntries(new URLSearchParams(location.search));
+    const token = parsed["token"] || parsed["?token"];
+    if (token?.length > 0) {
+      stateService.getCarnet(token)?.then((data) => {
+        setData(data);
+      });
     }
-  }, [parsed]);
+  }, [location.search]);
 
   return (
     <PageLayout

--- a/src/pages/agenda/components/AgendaTable.jsx
+++ b/src/pages/agenda/components/AgendaTable.jsx
@@ -129,7 +129,7 @@ const AgendaTable = () => {
           disabled={false}
           type="hoverable-cream"
           onClick={() => {}}
-          tooltip={t("events.tooltip.pago-taquilla")}
+          tooltip={`${t("events.tooltip.pago-taquilla")} / ${t("events.tooltip.pago-externo")}`}
         />
       );
 

--- a/src/pages/landing/SubscriptionFinished.jsx
+++ b/src/pages/landing/SubscriptionFinished.jsx
@@ -1,24 +1,24 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 import PageLayout from "../../components/layout/PageLayout/PageLayout";
 import { AMEBA_EMAIL } from "../../utils/constants";
 import "../../styles/GlobalStyles.css";
 import useProfileStore from "../../stores/useProfileStore";
 
-export default function SubscriptionFinished(props) {
+export default function SubscriptionFinished() {
   const subscribeNewsletter = useProfileStore((state) => state.subscribeNewsletter);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [t] = useTranslation("translation");
-
-  const parsed = Object.fromEntries(new URLSearchParams(props.location.search));
-  let email = parsed["email"]?.trim() || parsed["?email"]?.trim();
-  // Un email con un '+' lo recupera como espaciado, hay que reconstruirlo
-  if (email && email.indexOf(" ") > 0) email = email.replace(" ", "+");
+  const location = useLocation();
 
   useEffect(() => {
+    const parsed = Object.fromEntries(new URLSearchParams(location.search));
+    let email = parsed["email"]?.trim() || parsed["?email"]?.trim();
+    if (email && email.indexOf(" ") > 0) email = email.replace(" ", "+");
     if (email && email.length > 0)
       subscribeNewsletter(email).then(setIsSubmitted(true));
-  }, [email, subscribeNewsletter]);
+  }, [location.search, subscribeNewsletter]);
 
   return (
     <PageLayout

--- a/src/pages/profile/Profile.jsx
+++ b/src/pages/profile/Profile.jsx
@@ -28,6 +28,10 @@ export default function Profile() {
     return <Navigate to="/" replace />;
   }
 
+  if (location.pathname === "/profile") {
+    return <Navigate to="/profile/profile" replace />;
+  }
+
   const arrView = isMember
     ? [
         <MemberProfile isMember={isMember} key="member-profile" />,

--- a/src/pages/profile/views/MemberProfile.jsx
+++ b/src/pages/profile/views/MemberProfile.jsx
@@ -37,8 +37,6 @@ export default function MemberProfile({ setButtonDisabled, isMember }) {
             />
           )}
 
-          {isMember && !isMembershipExpired && <MemberQr />}
-
           <div className="member-profile-title">{t("perfil.dades")}</div>
           {isMember && !isMembershipExpired ? (
             <MembershipFormLayout setButtonDisabled={setButtonDisabled} />
@@ -84,6 +82,8 @@ export default function MemberProfile({ setButtonDisabled, isMember }) {
               closable
             />
           )}
+
+          {isMember && !isMembershipExpired && <MemberQr />}
         </div>
 
         {open && <SociDialog open={open} onClose={handleClick} />}

--- a/src/pages/qr-landing/QrLanding.jsx
+++ b/src/pages/qr-landing/QrLanding.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import DisclaimerBox from "../../components/disclaimerBox/DisclaimerBox";
 import PageLayout from "../../components/layout/PageLayout/PageLayout";
 import { AMEBA_EMAIL, BASE_URL, radioDublabLink } from "../../utils/constants";
@@ -7,13 +8,14 @@ import "../../styles/GlobalStyles.css";
 import "./QrLanding.css";
 import axiosInstance from "../../axios";
 
-const QrLanding = (props) => {
+const QrLanding = () => {
   const [memberData, setMemberData] = useState({});
-
+  const location = useLocation();
   const [t] = useTranslation("translation");
-  const parsed = Object.fromEntries(new URLSearchParams(props.location.search));
   const [loading, setLoading] = useState(true);
+
   useEffect(() => {
+    const parsed = Object.fromEntries(new URLSearchParams(location.search));
     const strToken = parsed["token"] || parsed["?token"];
     axiosInstance
       .get(BASE_URL + `member_card/?token=${strToken}`, {})
@@ -24,7 +26,7 @@ const QrLanding = (props) => {
       .catch(() => {
         setLoading(false);
       });
-  }, [parsed]);
+  }, [location.search]);
 
   return (
     <PageLayout


### PR DESCRIPTION
Summary
Fix Sentry crash (Cannot read properties of undefined (reading 'search')): Migrated 4 components from deprecated props.location.search (React Router v5 pattern) to useLocation() hook (v6): PasswordRecovery, QrClient, SubscriptionFinished, QrLanding
DICE external purchase links: When maps_url contains "dice", location fields now show "link de compra" label with translated link text instead of raw URL; removed dashed <hr> separator below the purchase button; removed underline from <a> wrapping buttons
Profile UX: /profile now redirects to /profile/profile; reordered MemberProfile to show personal data first, QR card below
AgendaTable: Updated "pago en taquilla" tooltip to include "compra externa"
Test plan
 Navigate to /recovery?token=xxx — verify no crash, token is parsed
 Navigate to /profile — verify redirect to /profile/profile
 Verify profile view shows personal data above QR card
 Open a DICE event modal — verify "LINK DE COMPRA / comprar entrades" label, no raw URL, no underline on button, no extra separator line
 Open a normal event modal — verify location/maps link still works as before