### PR TITLE
[fix/overflow-sizes-product]

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -484,9 +484,10 @@
 }
 
 .centered-element {
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100%;
+  min-height: 50vh;
   padding: 20px;
 }

--- a/src/components/cardView/CardView.css
+++ b/src/components/cardView/CardView.css
@@ -145,7 +145,6 @@
 .modal-card-location__row {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
   align-items: center;
   margin-bottom: 0.3em;
 }
@@ -230,10 +229,11 @@
 .interactiveDataBox-product-sizes__button_active,
 .interactiveDataBox-product-sizes__button {
   display: inline-flex;
-  width: 30px;
+  min-width: 30px;
   height: 30px;
   font-size: 1.8rem;
   margin-right: 0.15rem;
+  padding: 0 4px;
   justify-content: center;
   align-items: center;
   border: 3px solid var(--color-negro);

--- a/src/components/cardView/ProductDetails.jsx
+++ b/src/components/cardView/ProductDetails.jsx
@@ -26,7 +26,7 @@ const ProductDetails = ({
           {productSoldOut ? t("modal.esgotat") : t("modal.talles")} / &nbsp;
         </span>
       </div>
-      {sizes && sizes[0] === "UNIQUE" ? (
+      {(sizes && sizes[0] === "UNIQUE") || sizes?.length === 1 ? (
         <div className="modal-center-label">Talla única</div>
       ) : (
         <>
@@ -35,7 +35,7 @@ const ProductDetails = ({
             return (
               <div
                 className={
-                  activeSize === el || sizes.length === 1
+                  activeSize === el
                     ? "sizes interactiveDataBox-product-sizes__button_active"
                     : "sizes interactiveDataBox-product-sizes__button"
                 }


### PR DESCRIPTION
## Summary
- Replaced modal-based product/event/membership views with dedicated card view pages (`CardView`, `ActivitatPage`, `ProductePage`)
- Removed legacy modal system (`ModalCard.jsx`, `InteractiveModalBox.jsx`, `Modals.css`, `ExternalEvents`)
- Added new routing for `/activitats/:id`, `/botiga/:id`, and product redirects
- Added `FilterBar` component and `PowerTitle` enhancements
- Fixed product size button overflow for single-size items (e.g. "STANDARD") — auto-selects and displays as "Talla única"
- Updated CSS size buttons to use `min-width` instead of fixed `width` to prevent text overflow
- Version bump to 3.4.14

## Changed files
- **55 files** changed: +1440 / -2623 lines (net reduction of ~1183 lines)
- Key additions: `CardView.jsx/css`, `CardViewButton.jsx/css`, `EventDetails.jsx`, `ProductDetails.jsx`, `MembershipDetails.jsx`, `ItemDetails.jsx`, `ActivitatPage.jsx`, `ProductePage.jsx`, `ProductRedirect.jsx`, `FilterBar.jsx/css`
- Key removals: `ModalCard.jsx`, `Modals.css`, `InteractiveModalBox.jsx`, `ExternalEvent.jsx/css`, `ExternalEvents.jsx/css`, `Activitat.jsx`, `Producte.jsx`, `Soci.jsx`
